### PR TITLE
Removed separate `main` branch logic

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Cache generated content for existing tags
         uses: actions/cache@v3
         with:
-          # explicitly do not cache main or develop as they are likely to change
+          # explicitly do not cache develop as they are likely to change
           path: |
             site/content/models/v*/
             site/data/models/v*/

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  pull_request: {}
 jobs:
   deploy:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ clean: clean-modeldoc clean-site ## Clean all
 # Website generation / hugo
 #
 
-REVISIONS:=$(shell ./support/list_revisions.sh)
+REVISIONS:=develop $(shell ./support/list_revisions.sh)
 MODELDOC_CONTENT_DIR:=site/content/models
 MODELDOC_REVISION_CONTENT_DIR:=$(patsubst %,$(MODELDOC_CONTENT_DIR)/%/,$(REVISIONS))
 MODELDOC_DATA_DIR:=site/data/models

--- a/site/archetypes/complete-reference/_index.md
+++ b/site/archetypes/complete-reference/_index.md
@@ -8,6 +8,10 @@ sidenav:
   focusrenderdepth: 2
   activerenderdepth: -1
   inactiverenderdepth: 1
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/
+{{ end }}
 ---
 
 <p><span class="usa-tag">Release Version</span> {{ if eq (getenv "HUGO_REF_VERSION") "develop" }}Latest Development Snapshot{{ else }}OSCAL v{{ getenv "HUGO_REF_VERSION" }}{{ end }}</p>

--- a/site/archetypes/complete-reference/json-definitions.md
+++ b/site/archetypes/complete-reference/json-definitions.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1, h2.toc2, h3.toc3, h4.toc4, h5.toc5, h6.toc6"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/json-definitions/
+{{ end }}
 ---
 
 The following is a reference for the JSON object definitions derived from this model's [metaschema](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/src/metaschema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_metaschema.xml), which imports the metaschemas for all of the OSCAL models.

--- a/site/archetypes/complete-reference/json-index.md
+++ b/site/archetypes/complete-reference/json-index.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/json-index/
+{{ end }}
 ---
 
 The following is an index of each JSON property used in the [JSON format](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/json/schema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_schema.json), which represents the combination of all OSCAL models. Each entry in the index lists all uses of the given property in the format, which is linked to the corresponding entry in the [JSON Format Reference](../json-reference/). Each entry also lists the formal name for the definition which is linked to the corresponding JSON definition in the [JSON Format Metaschema Reference](../json-definitions/).

--- a/site/archetypes/complete-reference/json-outline.md
+++ b/site/archetypes/complete-reference/json-outline.md
@@ -7,6 +7,10 @@ weight: 10
 generateanchors: false
 sidenav:
   title: JSON Outline
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/json-outline/
+{{ end }}
 ---
 
 The following outline is a representation of the [JSON format](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/json/schema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_schema.json) for the combination of all OSCAL models. For each property, the name links to the corresponding entry in the [JSON Format Reference](../json-reference/). The cardinality and data type are also provided for each property where appropriate.

--- a/site/archetypes/complete-reference/json-reference.md
+++ b/site/archetypes/complete-reference/json-reference.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1, h2.toc2, h3.toc3, h4.toc4, h5.toc5, h6.toc6"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/json-reference/
+{{ end }}
 ---
 
 The following is the JSON format reference for the combination of all OSCAL models, which is organized hierarchically. Each entry represents the corresponding JSON property in the model's JSON format, and provides details about the semantics and use of the property. The [JSON Format Outline](../json-outline/) provides a streamlined, hierarchical representation of this model's JSON format which can be used along with this reference to better understand the JSON representation of this model.

--- a/site/archetypes/complete-reference/xml-definitions.md
+++ b/site/archetypes/complete-reference/xml-definitions.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1, h2.toc2, h3.toc3, h4.toc4, h5.toc5, h6.toc6"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/xml-definitions/
+{{ end }}
 ---
 
 The following is a reference for the XML element and attribute types derived from this model's [metaschema](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/src/metaschema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_metaschema.xml).

--- a/site/archetypes/complete-reference/xml-index.md
+++ b/site/archetypes/complete-reference/xml-index.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/xml-index/
+{{ end }}
 ---
 
 The following is an index of each XML element and attribute used in the [XML format](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/xml/schema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_schema.xsd) for this model. Each entry in the index lists all uses of the given element or attribute in the format, which is linked to the corresponding entry in the [XML Format Reference](../xml-reference/). Each entry also lists the formal name for the given element or attribute which is linked to the corresponding XML type in the [XML Format Metaschema Reference](../xml-definitions/).

--- a/site/archetypes/complete-reference/xml-outline.md
+++ b/site/archetypes/complete-reference/xml-outline.md
@@ -7,6 +7,10 @@ weight: 50
 generateanchors: false
 sidenav:
   title: XML Outline
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/xml-outline/
+{{ end }}
 ---
 
 The following outline is a representation of the [XML format](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/xml/schema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_schema.xsd) for the combination of all OSCAL models. For each element or attribute, the name links to the corresponding entry in the [XML Format Reference](../xml-reference/). The cardinality and data type are also provided for each element or attribute where appropriate.

--- a/site/archetypes/complete-reference/xml-reference.md
+++ b/site/archetypes/complete-reference/xml-reference.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1, h2.toc2, h3.toc3, h4.toc4, h5.toc5, h6.toc6"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/complete/xml-reference/
+{{ end }}
 ---
 
 The following is the XML format reference for the combination of all OSCAL models, which is organized hierarchically. Each entry represents the corresponding XML element or attribute in the model's XML format, and provides details about the semantics and use of the element or attribute. The [XML Format Outline](../xml-outline/) provides a streamlined, hierarchical representation of this model's XML format which can be used along with this reference to better understand the XML representation of this model.

--- a/site/archetypes/model-reference/_index.md
+++ b/site/archetypes/model-reference/_index.md
@@ -8,6 +8,10 @@ sidenav:
   focusrenderdepth: 1
   activerenderdepth: -1
   inactiverenderdepth: 1
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/
+{{ end }}
 ---
 
 <p><span class="usa-tag">Release Version</span> {{ if eq (getenv "HUGO_REF_VERSION") "develop" }}Latest Development Snapshot{{ else }}OSCAL v{{ getenv "HUGO_REF_VERSION" }}{{ end }}</p>

--- a/site/archetypes/model-reference/json-definitions.md
+++ b/site/archetypes/model-reference/json-definitions.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1, h2.toc2, h3.toc3, h4.toc4, h5.toc5, h6.toc6"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/json-definitions/
+{{ end }}
 ---
 
 The following is a reference for the JSON object definitions derived from the [metaschema](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}//src/metaschema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_metaschema.xml) for this [model](https://pages.nist.gov/OSCAL/concepts/layer/{{ getenv "HUGO_LAYER_ID" }}/{{ getenv "HUGO_MODEL_ID" }}/).

--- a/site/archetypes/model-reference/json-index.md
+++ b/site/archetypes/model-reference/json-index.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/json-index/
+{{ end }}
 ---
 
 The following is an index of each JSON property used in the [JSON format](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/json/schema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_schema.json) for this [model](https://pages.nist.gov/OSCAL/concepts/layer/{{ getenv "HUGO_LAYER_ID" }}/{{ getenv "HUGO_MODEL_ID" }}/). Each entry in the index lists all uses of the given property in the format, which is linked to the corresponding entry in the [JSON Format Reference](../json-reference/). Each entry also lists the formal name for the definition which is linked to the corresponding JSON definition in the [JSON Format Metaschema Reference](../json-definitions/).

--- a/site/archetypes/model-reference/json-outline.md
+++ b/site/archetypes/model-reference/json-outline.md
@@ -7,41 +7,10 @@ weight: 10
 generateanchors: false
 sidenav:
   title: JSON Outline
-{{ if eq (getenv "HUGO_REF_REVISION") "latest" -}}
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
 aliases:
-{{- if eq (getenv "HUGO_MODEL_ID") "assessment-plan" }}
-  - /documentation/schema/assessment-plan/json-model-map/
-  - /documentation/schema/assessment-layer/assessment-plan/json-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "assessment-results" }}
-  - /documentation/schema/assessment-results/json-model-map/
-  - /documentation/schema/assessment-results-layer/assessment-results/json-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "catalog" }}
-  - /docs/maps/oscal-catalog-json/
-  - /documentation/schema/catalog/json-model-map/
-  - /documentation/schema/catalog-layer/catalog/json-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "component-definition" }}
-  - /docs/maps/oscal-component-json/
-  - /documentation/schema/component/json-model-map/
-  - /documentation/schema/implementation-layer/component/json-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "plan-of-action-and-milestones" }}
-  - /documentation/schema/poam/json-model-map/
-  - /documentation/schema/assessment-results-layer/poam/json-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "profile" }}
-  - /docs/maps/oscal-profile-json/
-  - /documentation/schema/profile/json-model-map/
-  - /documentation/schema/profile-layer/profile/json-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "system-security-plan" }}
-  - /docs/maps/oscal-ssp-json/
-  - /documentation/schema/ssp/json-schema-map/
-  - /documentation/schema/implementation-layer/ssp/json-model-map/
-{{- end -}}
-{{- end }}
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/json-outline/
+{{ end }}
 ---
 
 The following outline is a representation of the [JSON format](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/json/schema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_schema.json) for this [model](https://pages.nist.gov/OSCAL/concepts/layer/{{ getenv "HUGO_LAYER_ID" }}/{{ getenv "HUGO_MODEL_ID" }}/). For each property, the name links to the corresponding entry in the [JSON Format Reference](../json-reference/). The cardinality and data type are also provided for each property where appropriate.

--- a/site/archetypes/model-reference/json-reference.md
+++ b/site/archetypes/model-reference/json-reference.md
@@ -8,41 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1, h2.toc2, h3.toc3, h4.toc4, h5.toc5, h6.toc6"
-{{ if eq (getenv "HUGO_REF_REVISION") "latest" -}}
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
 aliases:
-{{ if eq (getenv "HUGO_MODEL_ID") "assessment-plan" }}
-  - /documentation/schema/assessment-plan/json-schema/
-  - /documentation/schema/assessment-layer/assessment-plan/json-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "assessment-results" }}
-  - /documentation/schema/assessment-results/json-schema/
-  - /documentation/schema/assessment-results-layer/assessment-results/json-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "catalog" }}
-  - /docs/schemas/oscal-catalog-json/
-  - /documentation/schema/catalog/json-schema/
-  - /documentation/schema/catalog-layer/catalog/json-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "component-definition" }}
-  - /docs/schemas/oscal-component-json/
-  - /documentation/schema/component/json-schema/
-  - /documentation/schema/implementation-layer/component/json-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "plan-of-action-and-milestones" }}
-  - /documentation/schema/poam/json-schema/
-  - /documentation/schema/assessment-results-layer/poam/json-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "profile" }}
-  - /docs/schemas/oscal-profile-json/
-  - /documentation/schema/profile/json-schema/
-  - /documentation/schema/profile-layer/profile/json-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "system-security-plan" }}
-  - /docs/schemas/oscal-ssp-json/
-  - /documentation/schema/ssp/json-schema/
-  - /documentation/schema/implementation-layer/ssp/json-schema/
-{{- end -}}
-{{- end }}
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/json-reference/
+{{ end }}
 ---
 
 The following is the JSON format reference for this [model](https://pages.nist.gov/OSCAL/concepts/layer/{{ getenv "HUGO_LAYER_ID" }}/{{ getenv "HUGO_MODEL_ID" }}/), which is organized hierarchically. Each entry represents the corresponding JSON property in the model's JSON format, and provides details about the semantics and use of the property. The [JSON Format Outline](../json-outline/) provides a streamlined, hierarchical representation of this model's JSON format which can be used along with this reference to better understand the JSON representation of this model.

--- a/site/archetypes/model-reference/xml-definitions.md
+++ b/site/archetypes/model-reference/xml-definitions.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1, h2.toc2, h3.toc3, h4.toc4, h5.toc5, h6.toc6"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/xml-definitions/
+{{ end }}
 ---
 
 The following is a reference for the XML element and attribute types derived from the [metaschema](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}//src/metaschema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_metaschema.xml) for this [model](https://pages.nist.gov/OSCAL/concepts/layer/{{ getenv "HUGO_LAYER_ID" }}/{{ getenv "HUGO_MODEL_ID" }}/).

--- a/site/archetypes/model-reference/xml-index.md
+++ b/site/archetypes/model-reference/xml-index.md
@@ -8,6 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/xml-index/
+{{ end }}
 ---
 
 The following is an index of each XML element and attribute used in the [XML format](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/xml/schema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_schema.xsd) for this [model](https://pages.nist.gov/OSCAL/concepts/layer/{{ getenv "HUGO_LAYER_ID" }}/{{ getenv "HUGO_MODEL_ID" }}/). Each entry in the index lists all uses of the given element or attribute in the format, which is linked to the corresponding entry in the [XML Format Reference](../xml-reference/). Each entry also lists the formal name for the given element or attribute which is linked to the corresponding XML type in the [XML Format Metaschema Reference](../xml-definitions/).

--- a/site/archetypes/model-reference/xml-outline.md
+++ b/site/archetypes/model-reference/xml-outline.md
@@ -7,41 +7,10 @@ weight: 50
 generateanchors: false
 sidenav:
   title: XML Outline
-{{ if eq (getenv "HUGO_REF_REVISION") "latest" -}}
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
 aliases:
-{{- if eq (getenv "HUGO_MODEL_ID") "assessment-plan" }}
-  - /documentation/schema/assessment-plan/xml-model-map/
-  - /documentation/schema/assessment-layer/assessment-plan/xml-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "assessment-results" }}
-  - /documentation/schema/assessment-results/xml-model-map/
-  - /documentation/schema/assessment-results-layer/assessment-results/xml-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "catalog" }}
-  - /docs/maps/oscal-catalog-xml/
-  - /documentation/schema/catalog/xml-model-map/
-  - /documentation/schema/catalog-layer/catalog/xml-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "component-definition" }}
-  - /docs/maps/oscal-component-xml/
-  - /documentation/schema/component/xml-model-map/
-  - /documentation/schema/implementation-layer/component/xml-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "plan-of-action-and-milestones" }}
-  - /documentation/schema/poam/xml-model-map/
-  - /documentation/schema/assessment-results-layer/poam/xml-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "profile" }}
-  - /docs/maps/oscal-profile-xml/
-  - /documentation/schema/profile/xml-model-map/
-  - /documentation/schema/profile-layer/profile/xml-model-map/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "system-security-plan" }}
-  - /docs/maps/oscal-ssp-xml/
-  - /documentation/schema/ssp/xml-model-map/
-  - /documentation/schema/implementation-layer/ssp/xml-model-map/
-{{- end -}}
-{{- end }}
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/xml-outline/
+{{ end }}
 ---
 
 The following outline is a representation of the [XML format](https://github.com/usnistgov/OSCAL/blob/{{ getenv "HUGO_REF_BRANCH" }}/xml/schema/oscal_{{ getenv "HUGO_SCHEMA_ID" }}_schema.xsd) for this [model](https://pages.nist.gov/OSCAL/concepts/layer/{{ getenv "HUGO_LAYER_ID" }}/{{ getenv "HUGO_MODEL_ID" }}/). For each element or attribute, the name links to the corresponding entry in the [XML Format Reference](../xml-reference/). The cardinality and data type are also provided for each element or attribute where appropriate.

--- a/site/archetypes/model-reference/xml-reference.md
+++ b/site/archetypes/model-reference/xml-reference.md
@@ -8,41 +8,10 @@ sidenav:
 toc:
   enabled: true
   headingselectors: "h1.toc1, h2.toc2, h3.toc3, h4.toc4, h5.toc5, h6.toc6"
-{{ if eq (getenv "HUGO_REF_REVISION") "latest" -}}
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
 aliases:
-{{- if eq (getenv "HUGO_MODEL_ID") "assessment-plan" }}
-  - /documentation/schema/assessment-plan/xml-schema/
-  - /documentation/schema/assessment-layer/assessment-plan/xml-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "assessment-results" }}
-  - /documentation/schema/assessment-results/xml-schema/
-  - /documentation/schema/assessment-results-layer/assessment-results/xml-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "catalog" }}
-  - /docs/schemas/oscal-catalog-xml/
-  - /documentation/schema/catalog/xml-schema/
-  - /documentation/schema/catalog-layer/catalog/xml-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "component-definition" }}
-  - /docs/schemas/oscal-component-xml/
-  - /documentation/schema/component/xml-schema/
-  - /documentation/schema/implementation-layer/component/xml-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "plan-of-action-and-milestones" }}
-  - /documentation/schema/poam/xml-schema/
-  - /documentation/schema/assessment-results-layer/poam/xml-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "profile" }}
-  - /docs/schemas/oscal-profile-xml/
-  - /documentation/schema/profile/xml-schema/
-  - /documentation/schema/profile-layer/profile/xml-schema/
-{{- end -}}
-{{- if eq (getenv "HUGO_MODEL_ID") "system-security-plan" }}
-  - /docs/schemas/oscal-ssp-xml/
-  - /documentation/schema/ssp/xml-schema/
-  - /documentation/schema/implementation-layer/ssp/xml-schema/
-{{- end -}}
-{{- end }}
+  - /models/latest/{{ getenv "HUGO_MODEL_ID" }}/xml-reference/
+{{ end }}
 ---
 
 The following is the XML format reference for this [model](https://pages.nist.gov/OSCAL/concepts/layer/{{ getenv "HUGO_LAYER_ID" }}/{{ getenv "HUGO_MODEL_ID" }}/), which is organized hierarchically. Each entry represents the corresponding XML element or attribute in the model's XML format, and provides details about the semantics and use of the element or attribute. The [XML Format Outline](../xml-outline/) provides a streamlined, hierarchical representation of this model's XML format which can be used along with this reference to better understand the XML representation of this model.

--- a/site/archetypes/reference-index.md
+++ b/site/archetypes/reference-index.md
@@ -1,11 +1,11 @@
 ---
 title: "{{ if eq (getenv "HUGO_REF_VERSION") "develop" }}Development Snapshot Reference{{ else }}OSCAL v{{ getenv "HUGO_REF_VERSION" }} Reference{{ end }}"
-summary: "{{ if eq (getenv "HUGO_REF_REVISION") "develop" }}Development Snapshot{{ else if eq (getenv "HUGO_REF_REVISION") "latest" }}Latest Release (v{{ getenv "HUGO_REF_VERSION" }}){{ else }}{{ getenv "HUGO_REF_VERSION" }}{{ end }}"
+summary: "{{ if eq (getenv "HUGO_REF_VERSION") "develop" }}Development Snapshot{{ else if eq (getenv "HUGO_REF_LATEST") "true" }}Latest Release (v{{ getenv "HUGO_REF_VERSION" }}){{ else }}{{ getenv "HUGO_REF_VERSION" }}{{ end }}"
 layout: reference-release
-weight: {{ if eq (getenv "HUGO_REF_REVISION") "develop" }}20{{ else if eq (getenv "HUGO_REF_REVISION") "latest" }}50{{ else }}70{{ end }}
+weight: {{ if eq (getenv "HUGO_REF_VERSION") "develop" }}20{{ else if eq (getenv "HUGO_REF_LATEST") "true" }}50{{ else }}70{{ end }}
 sidenav:
-  title: {{ if eq (getenv "HUGO_REF_REVISION") "develop" }}Development Snapshot{{ else if eq (getenv "HUGO_REF_REVISION") "latest" }}Latest Release (v{{ getenv "HUGO_REF_VERSION" }}){{ else }}{{ getenv "HUGO_REF_VERSION" }}{{ end }}
-  focusrenderdepth: {{ if eq (getenv "HUGO_REF_REVISION") "latest" }}2{{ else }}1{{ end }}
+  title: {{ if eq (getenv "HUGO_REF_VERSION") "develop" }}Development Snapshot{{ else if eq (getenv "HUGO_REF_LATEST") "true" }}Latest Release (v{{ getenv "HUGO_REF_VERSION" }}){{ else }}{{ getenv "HUGO_REF_VERSION" }}{{ end }}
+  focusrenderdepth: {{ if eq (getenv "HUGO_REF_LATEST") "true" }}2{{ else }}1{{ end }}
   activerenderdepth: -1
   inactiverenderdepth: 1
   debug: false
@@ -13,6 +13,9 @@ oscal:
     type: "{{ getenv "HUGO_REF_TYPE" }}"
     remote: "{{ getenv "HUGO_REF_REMOTE" }}"
     branch: "{{ getenv "HUGO_REF_BRANCH" }}"
-    revision: "{{ getenv "HUGO_REF_REVISION" }}"
     version: "{{ getenv "HUGO_REF_VERSION" }}"
+{{ if eq (getenv "HUGO_REF_LATEST") "true" }}
+aliases:
+  - /models/latest/
+{{ end }}
 ---

--- a/support/generate_modeldoc.sh
+++ b/support/generate_modeldoc.sh
@@ -66,22 +66,19 @@ REF="$(cd "${SCRATCH_DIR}";git symbolic-ref -q --short HEAD || git describe --ta
 if [[ "$REF" =~ ^v.* ]]; then
   VERSION="${REF/#"v"}"
   TYPE="tag"
-  OUTPUT_DIR="${VERSION}"
-elif [ "$REF" = "main" ]; then
-  VERSION="$(cd "${SCRATCH_DIR}";git describe --abbrev=0)"
-  VERSION="${VERSION/#"v"}"
-  TYPE="branch"
-  OUTPUT_DIR="latest"
 else
   VERSION="${REF}"
   TYPE="branch"
-  OUTPUT_DIR="${REF}"
+fi
+
+LATEST=$("${ROOT_DIR}"/support/list_revisions.sh | tail -n 1)
+if [[ "$VERSION" == "${LATEST/#"v"}" ]]; then
+  export HUGO_REF_LATEST="true"
 fi
 
 export HUGO_REF_VERSION="${VERSION}"
 export HUGO_REF_BRANCH="${REF}"
 export HUGO_REF_TYPE="${TYPE}"
-export SITE_OUTPUT_DIR="${SITE_MODELDOC_DIR}/${OUTPUT_DIR}"
 # TODO parse remote (line 172 of original script)
 export HUGO_REF_REMOTE="usnistgov/OSCAL"
 

--- a/support/list_revisions.sh
+++ b/support/list_revisions.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# List the refs that generated documentation should target
-# Newest tag is excluded (as a duplicate of the "main" branch)
+# List the refs that generated documentation should target (oldest to newest)
 
 set -Eeuo pipefail
 
@@ -15,10 +14,5 @@ TAGS=$(cd "${OSCAL_DIR}"; git tag)
 TAGGED_REVISIONS=$(echo "${TAGS}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
 # sort tags (which should be in semver-ish format)
 TAGGED_REVISIONS=$(echo "${TAGGED_REVISIONS}" | sort -t "." -k1,1n -k2,2n -k3,3n)
-# exclude the last (newest) revision, which is duplicated by the "main" branch revision
-# solution compatible with macOS: https://stackoverflow.com/a/4881936
-TAGGED_REVISIONS=$(echo "${TAGGED_REVISIONS}" | awk 'NR>1{print buf}{buf = $0}')
 
-# always include "main" and "develop" revisions
-echo "develop"
 echo "${TAGGED_REVISIONS}"


### PR DESCRIPTION
* `list_revisions.sh` now only sorts and lists tagged revisions
* Added an alias to `latest` for all modeldoc pages

This should have the nice side effect of causing the GHA cache to include the latest revision.