### PR TITLE
Support local development with local directory override.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ clean: clean-modeldoc clean-site clean-release-assets ## Clean all
 #
 
 REVISIONS:=develop $(shell ./support/list_revisions.sh)
+LOCAL_OSCAL_DIR:=""
 MODELDOC_CONTENT_DIR:=site/content/models
 MODELDOC_REVISION_CONTENT_DIR:=$(patsubst %,$(MODELDOC_CONTENT_DIR)/%/,$(REVISIONS))
 MODELDOC_DATA_DIR:=site/data/models

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ To see other common operations, refer to the [`Makefile`](./Makefile) or simply 
 
 The target `make serve` runs builds the site dependencies and runs `hugo serve`.
 
+In some cases, this repository may be used to build documentation from a local copy of the OSCAL project, particularly in local branches, or a specific list of branches.  The branches and the OSCAL directory can be set from the command line to target specific changes:
+
+- `REVISIONS` - the list of branches. Multiple branches can be separated with a space.
+- `LOCAL_OSCAL_DIR` - the local path to the OSCAL repository.
+
+To generate the site:
+
+```sh
+make site REVISIONS="feature-new-model" LOCAL_OSCAL_DIR="/My/Local/Code/OSCAL"
+```
+
+To serve the site locally (with two branches):
+
+```sh
+make serve REVISIONS="feature-new-model feature-new-model-2" LOCAL_OSCAL_DIR="/My/Local/Code/OSCAL"
+```
+
 ### Speeding up the build
 
 Some tasks such as generating the model documentation can be done in parallel for each target release.

--- a/support/generate_modeldoc.sh
+++ b/support/generate_modeldoc.sh
@@ -9,6 +9,12 @@ SITE_DIR="${ROOT_DIR}/site"
 # Where generated content will be placed
 SITE_MODELDOC_DIR="${SITE_DIR}/content/models"
 OSCAL_DIR="${ROOT_DIR}/support/OSCAL"
+
+if [[ ${LOCAL_OSCAL_DIR:+1} ]] ; then
+  echo "LOCAL_OSCAL_DIR is set. Using local repository at ${LOCAL_OSCAL_DIR} instead of OSCAL_DIR."
+  OSCAL_DIR=${LOCAL_OSCAL_DIR}
+fi
+
 METASCHEMA_DIR="${ROOT_DIR}/support/metaschema-xslt"
 
 usage() {


### PR DESCRIPTION
In some cases, this repository may be used to build documentation from a local copy of the OSCAL project, particularly in local branches, or a specific list of branches.  The branches and the OSCAL directory can be set from the command line to target specific changes:

- `REVISIONS` - the list of branches. Multiple branches can be separated with a space.
- `LOCAL_OSCAL_DIR` - the local path to the OSCAL repository.

To generate the site:

```sh
make site REVISIONS="feature-new-model" LOCAL_OSCAL_DIR="/My/Local/Code/OSCAL"
```

To serve the site locally (with two branches):

```sh
make serve REVISIONS="feature-new-model feature-new-model-2" LOCAL_OSCAL_DIR="/My/Local/Code/OSCAL"
```