### PR TITLE
Allow OSCAL repository to report release assets

### DIFF
--- a/support/generate_release_assets_redirect.sh
+++ b/support/generate_release_assets_redirect.sh
@@ -56,13 +56,10 @@ done < <(find "${SCRATCH_DIR}/src/metaschema" \
         -a ! -name '*metadata*' \
     -exec basename {} _metaschema.xml ';')
 
-# For each metaschema, append the appropriate schema and converter assets
-ASSETS=(
-    "${ROOT_METASCHEMAS[@]/%/_schema.json}"
-    "${ROOT_METASCHEMAS[@]/%/_schema.xsd}"
-    "${ROOT_METASCHEMAS[@]/%/_json-to-xml-converter.xsl}"
-    "${ROOT_METASCHEMAS[@]/%/_xml-to-json-converter.xsl}"
-)
+ASSETS=()
+while IFS='' read -r asset; do
+  ASSETS+=("$asset")
+done < <(make -C "${SCRATCH_DIR}" list-release-artifacts)
 
 OUTPUT_PATH=release-assets/latest
 GH_RELEASES_URL=https://github.com/usnistgov/OSCAL/releases

--- a/support/generate_release_assets_redirect.sh
+++ b/support/generate_release_assets_redirect.sh
@@ -58,8 +58,8 @@ done < <(find "${SCRATCH_DIR}/src/metaschema" \
 
 ARTIFACTS=()
 while IFS='' read -r asset; do
-  ARTIFACTS+=("$artifact")
-done < <(make -C "${SCRATCH_DIR}" list-release-artifacts)
+  ARTIFACTS+=("$asset")
+done < <(make -C "${SCRATCH_DIR}/build" list-release-artifacts)
 
 OUTPUT_PATH=release-assets/latest
 GH_RELEASES_URL=https://github.com/usnistgov/OSCAL/releases

--- a/support/generate_release_assets_redirect.sh
+++ b/support/generate_release_assets_redirect.sh
@@ -56,9 +56,9 @@ done < <(find "${SCRATCH_DIR}/src/metaschema" \
         -a ! -name '*metadata*' \
     -exec basename {} _metaschema.xml ';')
 
-ASSETS=()
+ARTIFACTS=()
 while IFS='' read -r asset; do
-  ASSETS+=("$asset")
+  ARTIFACTS+=("$artifact")
 done < <(make -C "${SCRATCH_DIR}" list-release-artifacts)
 
 OUTPUT_PATH=release-assets/latest


### PR DESCRIPTION
Note this will only work in OSCAL >1.1.0

This requires the Makefile target `list-release-artifacts`, which was added in https://github.com/usnistgov/OSCAL/pull/1901 and will be in OSCAL 1.1.1. Earlier versions will *FAIL*