### PR TITLE
Modeldoc generator specifies the page base path, hugo build improvements

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: "0.110.0"
+          hugo-version: "0.118.2"
           extended: true
       - name: Setup swap space
         # The Hugo build can require a significant amount of memory

--- a/site/config.yaml
+++ b/site/config.yaml
@@ -24,3 +24,13 @@ menu:
     - name: Github
       url: https://github.com/usnistgov/OSCAL-Reference
       weight: 90
+# Disable RSS generation everywhere
+outputs:
+  page:
+    - HTML
+  home:
+    - HTML
+  section:
+    - HTML
+  taxonomy:
+    - HTML

--- a/support/generate_modeldoc.sh
+++ b/support/generate_modeldoc.sh
@@ -134,14 +134,20 @@ do {
   model_rawname=${model_basename#oscal_}
   model_rawname=${model_rawname%_metaschema.xml}
 
-  export HUGO_MODEL_DATA_DIR="data/models/${REVISION}/${model_rawname}"
-  model_data="${SITE_DIR}/$HUGO_MODEL_DATA_DIR"
+  # The path to the model relative to the hugo data dir, output dir, and site root
+  model_output_path="models/${REVISION}/${model_rawname}"
+
+  # The directory Hugo will read the models from relative to the site directory
+  export HUGO_MODEL_DATA_DIR="data/$model_output_path"
+
+  # The root of the OSCAL Reference site
+  page_base_path="OSCAL-Reference/$model_output_path/"
 
   mvn \
     --quiet \
     -f "${METASCHEMA_DIR}/support/pom.xml" exec:java \
     -Dexec.mainClass="com.xmlcalabash.drivers.Main" \
-    -Dexec.args="-i source=$model_path output-path=file://$model_data/ ${METASCHEMA_DIR}/src/document/write-hugo-metaschema-docs.xpl"
+    -Dexec.args="-i source=$model_path page-base-path=$page_base_path output-path=file://${SITE_DIR}/$HUGO_MODEL_DATA_DIR/ ${METASCHEMA_DIR}/src/document/write-hugo-metaschema-docs.xpl"
 
   archetype=""
   model_doc_path=""


### PR DESCRIPTION
This PR adjusts the generation script to take advantage of the new option added to the hugo pipeline allowing for the page base path to be specified (fixing all links).

Also changed:
- RSS feed generation has been disabled, significantly curbing Hugo's memory footprint
- Hugo's version has been updated (`0.110.0` -> `0.118.2`), potentially fixing some memory leaks