### PR TITLE
Fix release asset links for usnistgov/OSCAL-Pages#48

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ PROTOTYPE_BRANCHES_PREFIX:=prototype
 # For local development, `REVISIONS` can be overridden to build a subset of the site
 #   (e.g. `make site REVISIONS='v1.1.0 my-special-branch'`)
 REVISIONS:=develop $(shell ./support/list_revisions.sh) $(shell ./support/list_branches.sh ${PROTOTYPE_BRANCHES_REMOTE} ${PROTOTYPE_BRANCHES_PREFIX})
-
+# Release assets link
+RELEASE_ASSET_REDIRECTS_DIR:=site/content/release-assets/latest/
 MODELDOC_CONTENT_DIR:=site/content/models
 MODELDOC_REVISION_CONTENT_DIR:=$(patsubst %,$(MODELDOC_CONTENT_DIR)/%/,$(REVISIONS))
 MODELDOC_DATA_DIR:=site/data/models
@@ -63,12 +64,6 @@ $(MODELDOC_CONTENT_DIR)/%/:
 clean-modeldoc: ## Clean model documentation
 	rm -fr $(MODELDOC_REVISION_CONTENT_DIR)
 	rm -fr $(MODELDOC_REVISION_DATA_DIR)
-
-#
-# Release assets link
-#
-
-RELEASE_ASSET_REDIRECTS_DIR:=site/content/release-assets/latest/
 
 .PHONY: release-assets
 release-assets: $(RELEASE_ASSET_REDIRECTS_DIR) ## Generate redirects to latest release's assets

--- a/support/generate_release_assets_redirect.sh
+++ b/support/generate_release_assets_redirect.sh
@@ -42,7 +42,7 @@ function cleanup() {
 trap cleanup EXIT
 
 ASSETS=()
-for asset in $(make -sC "${SCRATCH_DIR}/build" list-release-artifacts GENERATED_DIR=''); do
+for asset in $(make -sC "${SCRATCH_DIR}/build" list-release-artifacts RELEASE="${REVISION}" GENERATED_DIR=""); do
   ASSETS+=("$asset")
 done
 

--- a/support/generate_release_assets_redirect.sh
+++ b/support/generate_release_assets_redirect.sh
@@ -42,7 +42,8 @@ function cleanup() {
 trap cleanup EXIT
 
 ASSETS=()
-for asset in $(make -sC "${SCRATCH_DIR}/build" list-release-artifacts RELEASE="${REVISION}" GENERATED_DIR=""); do
+# REVISION will be a tag of the form 'v1.2.3', we use a substitution to remove the v to be '1.2.3'
+for asset in $(make -sC "${SCRATCH_DIR}/build" list-release-artifacts RELEASE="${REVISION#v}" GENERATED_DIR=""); do
   ASSETS+=("$asset")
 done
 

--- a/support/generate_release_assets_redirect.sh
+++ b/support/generate_release_assets_redirect.sh
@@ -42,7 +42,7 @@ function cleanup() {
 trap cleanup EXIT
 
 ASSETS=()
-for asset in $(make -sC "${SCRATCH_DIR}/build" list-release-artifacts); do
+for asset in $(make -sC "${SCRATCH_DIR}/build" list-release-artifacts GENERATED_DIR=''); do
   ASSETS+=("$asset")
 done
 


### PR DESCRIPTION
As part of the issue above, we need to fix two issues to make sure that the release asset link generation functions correctly.

1. In the Makefile, we were binding `RELEASE_ASSET_REDIRECTS_DIR` to its default value after the relevant build target. This fails silently.
1. While testing and troubleshooting fix 1, we noticed that the make target `list-release-artifacts` for usnistgov/OSCAL includes the relative path for the artifacts, not just the file names. So the following path is created.

site/public/release-assets/latest/generated/oscal_complete_schema.xsd/index.html

The intended result is below.

site/public/release-assets/latest/oscal_complete_schema.xsd/index.html

A workaround in generate_release_assets_redirect.sh was used to blank out the sub-directory.