### PR TITLE
Update workflow to remove parallel build.

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -123,7 +123,7 @@ jobs:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
         # GHA runners have 2 CPUs
         run: |
-          make site -j2 \
+          make site \
             ${{ github.event.inputs.revisions != '' && format('REVISIONS=''{0}''', github.event.inputs.revisions) || '' }} \
             ${{ github.event.inputs.revisions == '' && github.event.inputs.prefix && format('PROTOTYPE_BRANCHES_PREFIX=''{0}''', github.event.inputs.prefix) || '' }}
       #


### PR DESCRIPTION
This is to rule out this as a source of the 'file exists' errors upon build.

Build are failing with [errors similar to](https://github.com/usnistgov/OSCAL-Reference/actions/runs/7170215689/job/19522429815#step:12:101):
```
Error: /home/runner/work/OSCAL-Reference/OSCAL-Reference/site/content/models/prototype-shared-responsibility-model/_index.md already exists
```

This may make the site builds take a little longer, but if we still see the errors, we can look at ways to address this, along with potential root cause.