### PR TITLE
Fix overlapping elements in the OSCAL Reference pages - issue #12

### DIFF
--- a/site/assets/scss/schema-docs.scss
+++ b/site/assets/scss/schema-docs.scss
@@ -346,7 +346,6 @@
     font-size: 1em;
     line-height: inherit;
     font-family: anchorjs-icons;
-    position: absolute;
     margin-left: -1em;
     padding-right: 0.5em;
 }


### PR DESCRIPTION
absolute positioning interrupts the height calculation of the row for longer named instances.