### PR TITLE
Show model deprecation, allow for pre-releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ environment:
 
 .PHONY: serve
 serve: modeldoc release-assets ## Spin up a static web server for local dev
-	cd site
-	hugo serve
+	cd site && hugo serve
 
 .PHONY: site
 site: $(SITE_OUTPUT_DIR) ## Build the site

--- a/site/assets/scss/schema-docs.scss
+++ b/site/assets/scss/schema-docs.scss
@@ -360,3 +360,7 @@
     font-family: anchorjs-icons;
     background-image: "⚓";
 }
+
+.OM-name-deprecated {
+    text-decoration: line-through;
+}

--- a/support/list_revisions.sh
+++ b/support/list_revisions.sh
@@ -11,8 +11,10 @@ OSCAL_DIR="${ROOT_DIR}/support/OSCAL"
 TAGS=$(cd "${OSCAL_DIR}"; git tag)
 
 # filter out non-version tags (anything that isn't in a vX.X.X, milestones, release candidates, etc.)
-TAGGED_REVISIONS=$(echo "${TAGS}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+TAGGED_REVISIONS=$(echo "${TAGS}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-\S+)?$')
 # sort tags (which should be in semver-ish format)
 TAGGED_REVISIONS=$(echo "${TAGGED_REVISIONS}" | sort -t "." -k1,1n -k2,2n -k3,3n)
+# Filter out pre-1.0 pre-releases
+TAGGED_REVISIONS=$(echo "${TAGGED_REVISIONS}" | grep -v -E '^v1\.0\.0-.*')
 
 echo "${TAGGED_REVISIONS}"


### PR DESCRIPTION
- Amend `list_revisions.sh` to include post 1.0 pre-releases

    Filter out `v1.0.0-` milestones and RCs for relevancy.

- Fix the Makefile "serve target"
- Advance `metaschema-xslt` submodule, incorporating https://github.com/usnistgov/metaschema-xslt/pull/115