### PR TITLE
Updated go from the deprecated version 1.20 to the latest  version 1.23

### DIFF
--- a/site/go.mod
+++ b/site/go.mod
@@ -1,5 +1,5 @@
 module github.com/usnistgov/OSCAL-Reference/site
 
-go 1.20
+go 1.23
 
 require github.com/usnistgov/hugo-uswds v1.0.0 // indirect


### PR DESCRIPTION
The site was using a deprecated go version. 